### PR TITLE
Read patterns line-wise from patterns file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cgrep [OPTIONS] [ITEM]
 
 Pattern:
 
-    -f --file=FILE            read PATTERNs from file
+    -f --file=FILE            read PATTERNs from file (one per line)
     -w --word                 force word matching
     -p --prefix               force prefix matching
     -s --suffix               force suffix matching

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -85,7 +85,7 @@ putRecursiveContents opts inchan topdir langs prunedir visited = do
 readPatternsFromFile :: FilePath -> IO [C.ByteString]
 readPatternsFromFile f =
     if null f then return []
-              else liftM C.words $ C.readFile f
+              else liftM C.lines $ C.readFile f
 
 main :: IO ()
 main = do


### PR DESCRIPTION
Ok, couldn't help it but propose that change.

It works like expected for me now, but I'm still unsure if my expectation is correct:

```console
$ cat patterns
Sed etiam
$ cabal run cgrep -- -f patterns -d2 test/test.erl
Preprocessing executable 'cgrep' for cgrep-6.4.12...
Cgrep 6.4.12!
options   : Options {file = "patterns", word_match = False, prefix_match = False, suffix_match = False, edit_dist = False, ignore_case = False, regex = False, code = False, comment = False, literal = False, semantic = False, identifier = False, keyword = False, directive = False, header = False, number = False, string = False, char = False, oper = False, no_filename = False, no_linenumber = False, lang = [], lang_maps = False, force_language = Nothing, jobs = 1, multiline = 1, recursive = False, deference_recursive = False, invert_match = False, max_count = 9223372036854775807, count = False, show_match = False, color = False, format = Nothing, json = False, xml = False, debug = 2, no_turbo = False, others = ["test/test.erl"]}
languages : []
pattern   : ["Sed etiam"]
files     : ["test/test.erl"]
isTermIn  : False
isTermOut : False
strategy  : running string search on test/test.erl...
tokens    : [(197,"Sed etiam")]
tokens'   : [(197,"Sed etiam")]
test/test.erl:7:io:format("Sed etiam a suspendisse. \"Aliquam nulla erat risus.\"~n").
```

Thanks for cgrep, btw, great tool.
Stephan