### PR TITLE
added Cabal flag UsePcreRegexes

### DIFF
--- a/cgrep.cabal
+++ b/cgrep.cabal
@@ -14,6 +14,10 @@ Build-type:          Simple
 Extra-source-files:  README.md
 Cabal-version:       >=1.10
 
+Flag UsePcreRegexes
+  Description: Use PCRE instead of Posix regexes
+  Default:     False
+
 Executable cgrep
   Main-Is:             Main.hs
   Hs-Source-Dirs:      src
@@ -41,7 +45,6 @@ Executable cgrep
                        safe >=0.3, 
                        stringsearch >=0.3, 
                        unordered-containers >=0.1, 
-                       regex-posix >=0.90,
                        either >= 4.0,
                        mtl >= 2.0,
                        unix-compat >= 0.4,
@@ -49,3 +52,9 @@ Executable cgrep
                        transformers
   Ghc-options:         -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
   Default-language:    Haskell2010
+
+  if flag(UsePcreRegexes)
+    Build-Depends: regex-pcre >=0.90
+    Cpp-options: -DENABLE_PCRE
+  else
+    Build-Depends: regex-posix >=0.90

--- a/src/CGrep/Strategy/Regex.hs
+++ b/src/CGrep/Strategy/Regex.hs
@@ -24,7 +24,11 @@ import qualified Data.ByteString.Char8 as C
 
 import Control.Monad.Trans.Reader
 import Control.Monad.IO.Class
+#ifdef ENABLE_PCRE
+import Text.Regex.PCRE
+#else
 import Text.Regex.Posix
+#endif
 import Data.Array
 
 import CGrep.Common


### PR DESCRIPTION
which enables to configure cgrep for using PCRE instead of default
Posix regexes.

Build PCRE support with

```
cabal configure -fUsePcreRegexes
cabal build
```

Why I needed that. There is a small story... I have been using cgrep not too long and when playing with it I found some inconsistency that I first identified as POSIX regex deficiency (see issue #25) ... but it was not. I tried to match ``^\s*class`` in a small directory with files that contain lines like

```cpp
class Foo
```

All lines with word ``class`` had extra new line before them. I got very strange result:

```
# cgrep -rG '^\s*class'
./ldap_sf.h:28:
./ldap_sf_eval.h:34:
./ldap_sf_ptr.h:27:
```

Why are the matches invisible? Further debugging answered this question:

```
#  cgrep -rG --show-match '^\s*class'
./ldap_sf.h:28:["\nclass"]
./ldap_sf_eval.h:34:["\nclass"]
./ldap_sf_ptr.h:27:["\nclass"]
```

Source code investigation has shown that cgrep unlike other tools like *grep* or *ack* checks for matches within whole file with newlines as opposite to line-by-line checking. That's why two repetitive new lines will match "\nclass" whereas one newline will match just "class", and PCRE regexes will not help here. So I needed some character class that included all whitespaces except newlines. PCRE provided such a class: *\h* whereas Posix regexes did not.

PCRE regexes has many more advantages before Posix regexes and building them in cgrep is a good option.