### PR TITLE
hilightLine speed improvement

### DIFF
--- a/src/CGrep/Output.hs
+++ b/src/CGrep/Output.hs
@@ -224,15 +224,21 @@ hilightLine :: [Token] -> String -> String
 hilightLine ts =  hilightLine' (hilightIndicies ts, 0, 0)
     where hilightLine' :: ([(Int, Int)], Int, Int) -> String -> String
           hilightLine'  _ [] = []
-          hilightLine' (ns, n, bs) (x:xs) = (case () of
-                                                 _ | check && bs' == 0 -> if fst stack > 0 then bold ++ [x] ++ resetTerm
-                                                                                           else x : resetTerm
-                                                   | check && bs' > 0 -> bold ++ [x]
-                                                   | otherwise -> [x]
-                                            ) ++ hilightLine' (ns, n+1, bs') xs
+          hilightLine' (ns, n, bs) s@(x:_) = (case () of
+                                                  _ | check && bs' == 0 -> if fst stack > 0 then bold ++ [x] ++ resetTerm
+                                                                                            else x : resetTerm
+                                                    | check && bs' > 0 -> bold ++ [x]
+                                                    | otherwise -> next
+                                             ) ++ hilightLine' (ns, n + nn, bs') rest
             where stack = foldr (\(a, b) (c, d) -> (c + fromEnum (a == n), d + fromEnum (b == n))) (0, 0) ns
                   check = fst stack > 0 || snd stack > 0
                   bs' = bs + fst stack - snd stack
+                  plain = nub . sort $ foldr (\(a, b) acc -> a : b : acc) [] ns
+                  nn | check = 1
+                     | null plain' = length s
+                     | otherwise = head plain' - n
+                         where plain' = dropWhile (<=n) plain
+                  (next, rest) = splitAt nn s
 
 hilightIndicies :: [Token] -> [(Int, Int)]
 hilightIndicies = foldr (\t a -> let b = fst t in (b, b + length (snd t) - 1) : a) []


### PR DESCRIPTION
hilightLine now concatenates whole areas delimited by color stack
instead of every next character separately.

Nicola, I added a smaller improvement in ``hilightLine``. Not that I really detected real speed improvement after it, but the change made concatenation algorithm cleaner by retirement of concatenation of every character by ``(++)``.