### PR TITLE
keep case of semantic keywords when ignorecase set

### DIFF
--- a/src/CGrep/CGrep.hs
+++ b/src/CGrep/CGrep.hs
@@ -16,7 +16,7 @@
 -- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 --
 
-module CGrep.CGrep (sanitizeOptions, runCgrep) where
+module CGrep.CGrep (sanitizeOptions, runCgrep, isRegexp) where
 
 import qualified CGrep.Strategy.BoyerMoore       as BoyerMoore
 import qualified CGrep.Strategy.Levenshtein      as Levenshtein

--- a/src/CGrep/Output.hs
+++ b/src/CGrep/Output.hs
@@ -243,5 +243,5 @@ hilightLine ts =  hilightLine' (hilightIndicies ts, 0, 0)
                   (next, rest) = splitAt nn s
 
 hilightIndicies :: [Token] -> [(Int, Int)]
-hilightIndicies = foldr (\t a -> let b = fst t in (b, b + length (snd t) - 1) : a) [] . filter ((>0) . length . snd)
+hilightIndicies = foldr (\t a -> let b = fst t in (b, b + length (snd t) - 1) : a) [] . filter (not . null . snd)
 

--- a/src/CGrep/Parser/WildCard.hs
+++ b/src/CGrep/Parser/WildCard.hs
@@ -20,6 +20,7 @@ module CGrep.Parser.WildCard (WildCard(..), MultiCard,
                                 mkWildCardFromToken,
                                 combineMultiCard,
                                 filterTokensWithMultiCards,
+                                wildCardMap,
                                 wildCardMatch,
                                 multiCardMatch) where
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -214,9 +214,9 @@ main = do
                                     else readPatternsFromFile $ file opts
 
     let patterns' = map (if ignore_case opts then ic else id) patterns
-            where ic | (not . isRegexp) opts && semantic opts = C.unwords . map (\p -> if C.unpack p `M.member` wildCardTokens then p else C.map toLower p) . C.words
+            where ic | (not . isRegexp) opts && semantic opts = C.unwords . map (\p -> if C.unpack p `elem` wildCardTokens then p else C.map toLower p) . C.words
                      | otherwise = C.map toLower
-                        where wildCardTokens = wildCardMap `M.union` M.singleton "OR" AnyCard   -- "OR" is not included in wildCardMap
+                        where wildCardTokens = "OR" : M.keys wildCardMap   -- "OR" is not included in wildCardMap
 
     -- load files to parse:
 


### PR DESCRIPTION
Now it won't lower-case semantic keywords when option ``-i`` is set