### PR TITLE
cgrep: fix isSymbolicLink collision

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -45,7 +45,7 @@ import System.Console.CmdArgs
 import System.Directory
 import System.FilePath ((</>), takeFileName)
 import System.Environment
-import System.PosixCompat.Files
+import System.PosixCompat.Files as PosixCompat
 import System.IO
 import System.Exit
 import System.Process (readProcess)
@@ -102,7 +102,7 @@ withRecursiveContents opts dir langs prunedir visited action = do
                forM_ dirs $ \path -> do
                     let dirname = takeFileName path
                     lstatus <- getSymbolicLinkStatus path
-                    when ( deference_recursive opts || not (isSymbolicLink lstatus)) $
+                    when ( deference_recursive opts || not (PosixCompat.isSymbolicLink lstatus)) $
                         unless (dirname `elem` prunedir) $ do -- this is a good directory (unless already visited)!
                             cpath <- canonicalizePath path
                             unless (cpath `Set.member` visited) $ withRecursiveContents opts path langs prunedir (Set.insert cpath visited) action


### PR DESCRIPTION
System.Directory.isSymbolicLink collides with
System.PosixCompat.Files.isSymbolicLink (and with
System.Posix.Files.isSymbolicLink)

This applies the solution proposed here:
https://github.com/haskell/directory/issues/52#issuecomment-220879392