### PR TITLE
Fixes for two problems

### DIFF
--- a/src/CGrep/Output.hs
+++ b/src/CGrep/Output.hs
@@ -72,11 +72,10 @@ getOffsetsLines txt = let l = C.length txt in filter (<(l-1)) $ C.elemIndices '\
 
 
 getOffset2d :: [OffsetLine] -> Offset -> Offset2d
-getOffset2d idx off = let prc =  fst $ partition (< off) idx in
-        case prc of
-          [] -> (0, off)
-          _  -> (length prc, off - last prc - 1)
-
+getOffset2d idx off =
+  let prc = filter (< off) idx
+      (len_prc, last_prc) = foldl' (\(len,_) cur -> (len + 1, cur)) (0,off) prc
+  in (len_prc, off - last_prc - 1)
 
 mkOutput :: (Monad m) => FilePath -> Text8 -> Text8 -> [Token] -> OptionT m [Output]
 mkOutput f text multi ts = do

--- a/src/CGrep/Output.hs
+++ b/src/CGrep/Output.hs
@@ -243,6 +243,7 @@ showFile conf opt = showFileName conf opt . outFilePath
 showLineCol :: Options -> Output -> String
 showLineCol Options{no_numbers = True } _ = ""
 showLineCol Options{no_numbers = False, no_column = True  } (Output _ n _ _)  = show n
+showLineCol Options{no_numbers = False, no_column = False } (Output _ n _ []) = show n 
 showLineCol Options{no_numbers = False, no_column = False } (Output _ n _ ts) = show n ++ ":" ++ show ((+1) . fst . head $ ts)
 
 


### PR DESCRIPTION
Hi,
these changes fix two problems.

1) --invert-match is broken
$ cat <<END | stack exec cgrep -- -v foo
foo
bar
END
Using 'cgreprc' configuration file...
cgrep: Prelude.head: empty list

With my change, I get the expected result:
$cat <<END | stack exec cgrep -- -v foo
foo
bar
END
Using 'cgreprc' configuration file...
<STDIN>:2:bar



2) Output.getOffset2d has a memory leak

When run on a long file with many matching lines,
cgrep becomes very slow. For instance,
I used a list of english-words and searched for the word
"house" which matches many lines:

$ git clone https://github.com/dwyl/english-words 
$ time stack exec cgrep -- house english-words/words.txt
Using 'cgreprc' configuration file...
english-words/words.txt:7345:4:alehouse
english-words/words.txt:7346:4:alehouses
english-words/words.txt:8584:5:almshouse
english-words/words.txt:8585:5:almshouses
(...)
english-words/words.txt:351557:5:workhouse
english-words/words.txt:351558:5:workhoused
english-words/words.txt:351559:5:workhouses

real    1m29.212s
user    0m26.680s
sys     0m10.784s


The problem is a memory leak in Output.getOffset2d caused by the sharing of the 
list prc defined in this function.
Doing the same search with my change to Output.getOffset2d yields the following statistics:

real    0m3.212s
user    0m3.116s
sys     0m0.260s

Frederik
