### PR TITLE
Improve performance of Output.mkOutput

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CGrep: a context-aware grep for source codes
 Usage
 -----
 
-Cgrep 6.6.15. Usage: cgrep [OPTION] [PATTERN] files...
+Cgrep 6.6.17. Usage: cgrep [OPTION] [PATTERN] files...
 
 cgrep [OPTIONS] [ITEM]
 

--- a/cgrep.cabal
+++ b/cgrep.cabal
@@ -1,6 +1,6 @@
 Name:                cgrep
 Description:         Cgrep: a context-aware grep for source codes
-Version:             6.6.16
+Version:             6.6.17
 Synopsis:            Command line tool
 Homepage:            http://awgn.github.io/cgrep/
 License:             GPL-2

--- a/src/CGrep/Token.hs
+++ b/src/CGrep/Token.hs
@@ -30,7 +30,7 @@ import CGrep.Types
 
 
 type Token      = (Offset, String)
-type MatchLine  = (OffsetLine, [Token])
+type MatchLine  = (OffsetLine, Offset, Int, [Token]) -- (Line number, start, length, match list)
 type DString    = DL.DList Char
 
 


### PR DESCRIPTION
This is a follow-up to my last pull request.

It contains a suggestion for a more fundamental change to Output.mkOutput which achieves 
a linear running time.

The current implementation is still very slow when there are lots of matches.
This can be seen most easily with a search which matches most lines of a large file, say:
$ cgrep-v foo english-words/words.txt
 
(where words.txt is the large list of english words from the last pull request)

With the current implementation, this does not terminate after a reasonable time.

(The code has been tested to produce the same output as the current implementation, but clearly should be reviewed carefully.)
