### PR TITLE
fix: Incorrect column numbers.

### DIFF
--- a/src/CGrep/Match.hs
+++ b/src/CGrep/Match.hs
@@ -184,7 +184,7 @@ buildLineCol :: Options -> Match -> TLB.Builder
 buildLineCol Options{no_numbers = True} _ = mempty
 buildLineCol Options{no_numbers = False, no_column = True} (Match _ n _ _) = TLB.decimal n
 buildLineCol Options{no_numbers = False, no_column = False} (Match _ n _ []) = TLB.decimal n
-buildLineCol Options{no_numbers = False, no_column = False} (Match _ n l (t : _)) = TLB.decimal n <> TLB.singleton ':' <> TLB.decimal (bytesToCharOffset l (cOffset t) + 1)
+buildLineCol Options{no_numbers = False, no_column = False} (Match _ n l (t : _)) = TLB.decimal n <> TLB.singleton ':' <> TLB.decimal (bytesToCharOffset l (cOffset t - textOffsetWord8 l) + 1)
 {-# INLINE buildLineCol #-}
 
 bytesToCharOffset :: T.Text -> Int -> Int


### PR DESCRIPTION
## Problem
Incorrect column numbers, result of column always be end column.  
relate: https://github.com/awgn/cgrep/issues/52

## Solution
Use textOffsetWord8 in the calculation to obtain the column numbers.

## test
`$ cabal run cgrep -- -r main ./test`
**befor**
<img width="887" height="714" alt="image" src="https://github.com/user-attachments/assets/221625e4-3b16-465e-bf13-bee260bc1e29" />
**after**
<img width="938" height="710" alt="image" src="https://github.com/user-attachments/assets/3d1a839e-03fd-46c9-b10f-ab975d936b27" />
